### PR TITLE
Restructure column configurer API to avoid static methods

### DIFF
--- a/vaadin-grid-pro-flow-demo/src/main/java/com/vaadin/flow/component/gridpro/vaadincom/GridProView.java
+++ b/vaadin-grid-pro-flow-demo/src/main/java/com/vaadin/flow/component/gridpro/vaadincom/GridProView.java
@@ -1,15 +1,14 @@
 package com.vaadin.flow.component.gridpro.vaadincom;
 
-import com.vaadin.flow.component.gridpro.EditColumnConfigurator;
-import com.vaadin.flow.component.gridpro.GridPro;
-import com.vaadin.flow.demo.DemoView;
-import com.vaadin.flow.router.Route;
-
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Random;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
+
+import com.vaadin.flow.component.gridpro.GridPro;
+import com.vaadin.flow.demo.DemoView;
+import com.vaadin.flow.router.Route;
 
 @Route("vaadin-grid-pro")
 public class GridProView extends DemoView {
@@ -39,7 +38,7 @@ public class GridProView extends DemoView {
          * Lambda provided as a parameter for .text() method is a callback function that will
          * be called when item is changed.
          */
-        grid.addEditColumn(Person::getEmail, EditColumnConfigurator.text((item, newValue) -> {})).setHeader("Email (editable)");
+        grid.addEditColumn(Person::getEmail).text((item, newValue) -> {}).setHeader("Email (editable)");
         // end-source-example
 
         addCard("Basic Grid Pro", grid);
@@ -55,15 +54,15 @@ public class GridProView extends DemoView {
          * Using EditColumnConfigurator it is possible to define the type of the editor:
          * "text", "checkbox" or "select" and provide needed parameters.
          */
-        grid.addEditColumn(Person::getName, EditColumnConfigurator.text((item, newValue) -> {})).setHeader("Name (editable)");
+        grid.addEditColumn(Person::getName).text((item, newValue) -> {}).setHeader("Name (editable)");
 
-        grid.addEditColumn(Person::isSubscriber, EditColumnConfigurator.checkbox((item, newValue) -> {})).setHeader("Subscriber (editable)");
+        grid.addEditColumn(Person::isSubscriber).checkbox((item, newValue) -> {}).setHeader("Subscriber (editable)");
 
         List<String> optionsList = new ArrayList<>();
         optionsList.add("bla-bla@vaadin.com");
         optionsList.add("bla-bla@gmail.com");
         optionsList.add("super-mail@gmail.com");
-        grid.addEditColumn(Person::getEmail, EditColumnConfigurator.select((item, newValue) -> {}, optionsList)).setHeader("Email (editable)");
+        grid.addEditColumn(Person::getEmail).select((item, newValue) -> {}, optionsList).setHeader("Email (editable)");
         // end-source-example
 
         addCard("Editor Types", grid);
@@ -79,7 +78,7 @@ public class GridProView extends DemoView {
          * It is possible to allow enter pressing change the row by using grid pro method setEnterNextRow.
          */
         grid.setEnterNextRow(true);
-        grid.addEditColumn(Person::getName, EditColumnConfigurator.text((item, newValue) -> {})).setHeader("Name (editable)");
+        grid.addEditColumn(Person::getName).text((item, newValue) -> {}).setHeader("Name (editable)");
         // end-source-example
 
         addCard("Enter Next Row", grid);
@@ -95,7 +94,7 @@ public class GridProView extends DemoView {
          * It is possible to preserve edit mode when moving to the next cell by using grid pro method setKeepEditorOpen.
          */
         grid.setKeepEditorOpen(true);
-        grid.addEditColumn(Person::getEmail, EditColumnConfigurator.text((item, newValue) -> {})).setHeader("Email (editable)");
+        grid.addEditColumn(Person::getEmail).text((item, newValue) -> {}).setHeader("Email (editable)");
         // end-source-example
 
         addCard("Keep Editor Open", grid);

--- a/vaadin-grid-pro-flow-integration-tests/src/main/java/com/vaadin/flow/component/gridpro/examples/MainView.java
+++ b/vaadin-grid-pro-flow-integration-tests/src/main/java/com/vaadin/flow/component/gridpro/examples/MainView.java
@@ -1,16 +1,15 @@
 package com.vaadin.flow.component.gridpro.examples;
 
-import com.vaadin.flow.component.gridpro.EditColumnConfigurator;
-import com.vaadin.flow.component.gridpro.GridPro;
-import com.vaadin.flow.component.html.Div;
-import com.vaadin.flow.component.orderedlayout.VerticalLayout;
-import com.vaadin.flow.router.Route;
-
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Random;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
+
+import com.vaadin.flow.component.gridpro.GridPro;
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.orderedlayout.VerticalLayout;
+import com.vaadin.flow.router.Route;
 
 @Route
 public class MainView extends VerticalLayout {
@@ -28,27 +27,27 @@ public class MainView extends VerticalLayout {
 
         grid.addColumn(Person::getAge).setHeader("Age");
 
-        grid.addEditColumn(Person::getName, EditColumnConfigurator.text((item, newValue) -> {
+        grid.addEditColumn(Person::getName).text((item, newValue) -> {
             item.setName(newValue);
             itemDisplayPanel.setText(item.toString());
             subPropertyDisplayPanel.setText(newValue);
-        })).setHeader("Name").setWidth("300px");
+        }).setHeader("Name").setWidth("300px");
 
-        grid.addEditColumn(Person::isSubscriber, EditColumnConfigurator.checkbox((item, newValue) -> {
+        grid.addEditColumn(Person::isSubscriber).checkbox((item, newValue) -> {
             item.setSubscriber(newValue);
             itemDisplayPanel.setText(item.toString());
             subPropertyDisplayPanel.setText(newValue.toString());
-        })).setHeader("Subscriber").setWidth("300px");
+        }).setHeader("Subscriber").setWidth("300px");
 
         List<String> listOptions = new ArrayList<>();
         listOptions.add("Services");
         listOptions.add("Marketing");
         listOptions.add("Sales");
-        grid.addEditColumn(Person::getDepartment, EditColumnConfigurator.select((item, newValue) -> {
+        grid.addEditColumn(Person::getDepartment).select((item, newValue) -> {
             item.setDepartment(Department.valueOf(newValue));
             itemDisplayPanel.setText(item.toString());
             subPropertyDisplayPanel.setText(newValue);
-        }, listOptions)).setHeader("Department").setWidth("300px");
+        }, listOptions).setHeader("Department").setWidth("300px");
 
         add(grid, itemDisplayPanel, subPropertyDisplayPanel);
     }

--- a/vaadin-grid-pro-flow/src/main/java/com/vaadin/flow/component/gridpro/EditColumnConfigurator.java
+++ b/vaadin-grid-pro-flow/src/main/java/com/vaadin/flow/component/gridpro/EditColumnConfigurator.java
@@ -17,132 +17,148 @@ package com.vaadin.flow.component.gridpro;
  * #L%
  */
 
-import com.vaadin.flow.function.SerializableFunction;
-
 import java.io.Serializable;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.List;
-import java.util.Objects;
-import java.util.Map;
 import java.util.HashMap;
-import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
 
+import com.vaadin.flow.component.grid.Grid.Column;
+import com.vaadin.flow.component.gridpro.GridPro.EditColumn;
+import com.vaadin.flow.function.SerializableFunction;
 
 /**
- * Configuration class with common available properties for different types of edit columns used
- * inside a {@link GridPro}.
+ * Configuration for the editor of an edit column.
  *
  * @author Vaadin Ltd.
+ * @param <T>
+ *            the grid bean type
  */
 public class EditColumnConfigurator<T> implements Serializable {
 
-    private ItemUpdater<T, String> itemUpdater;
-    private EditorType type;
-    private List<String> options;
+    private final EditColumn<T> column;
 
-    private EditColumnConfigurator(ItemUpdater<T, String> itemUpdater, EditorType type, List<String> options) {
-        this.itemUpdater = itemUpdater;
-        this.type = type;
-        this.options = options;
+    /**
+     * Creates a new configurator for the given column.
+     *
+     * @param column
+     *            the column to edit, not <code>null</code>
+     */
+    public EditColumnConfigurator(EditColumn<T> column) {
+        assert column != null;
+        this.column = column;
     }
 
-    protected EditorType getType() {
-        return this.type;
-    }
+    private Column<T> configureColumn(ItemUpdater<T, String> itemUpdater,
+            EditorType type, List<String> options) {
+        column.setEditorType(type);
+        column.setItemUpdater(itemUpdater);
+        column.setOptions(options);
 
-    protected ItemUpdater<T, String> getItemUpdater() {
-        return this.itemUpdater;
-    }
-
-    protected List<String> getOptions() {
-        return this.options;
+        return getColumn();
     }
 
     /**
-     * Constructs a new column configurator with text editor preset for column creation.
+     * Gets the column.
      *
-     * @param <T>
-     *            the grid bean type
+     * @return the configured column
+     */
+    public Column<T> getColumn() {
+        return column;
+    }
+
+    /**
+     * Configures the column to have a text editor with the given item updater.
+     *
      * @param itemUpdater
      *            the callback function that is called when item is changed.
      *            It receives two arguments: item, newValue.
-     * @return the instance of EditColumnConfigurator
+     * @return the configured column
      *
      */
-    public static <T> EditColumnConfigurator<T> text(ItemUpdater<T, String> itemUpdater) {
-        return new EditColumnConfigurator<>(itemUpdater, EditorType.TEXT, Collections.emptyList());
+    public Column<T> text(ItemUpdater<T, String> itemUpdater) {
+        return configureColumn(itemUpdater, EditorType.TEXT,
+                Collections.emptyList());
     }
 
     /**
-     * Constructs a new column configurator with checkbox editor preset for column creation.
+     * Configures the column to have a checkbox editor with the given item
+     * updater.
      *
-     * @param <T>
-     *            the grid bean type
      * @param itemUpdater
      *            the callback function that is called when item is changed.
-     *            It receives two arguments: item and newValue.
-     * @return the instance of EditColumnConfigurator
+     *            It receives two arguments: item, newValue.
+     * @return the configured column
      */
-    public static <T> EditColumnConfigurator<T> checkbox(ItemUpdater<T, Boolean> itemUpdater) {
-        ItemUpdater<T, String> wrapper = (item, value) -> itemUpdater.accept(item, Boolean.valueOf(value));
+    public Column<T> checkbox(ItemUpdater<T, Boolean> itemUpdater) {
+        ItemUpdater<T, String> wrapper = (item, value) -> itemUpdater
+                .accept(item, Boolean.valueOf(value));
 
-        return new EditColumnConfigurator<>(wrapper, EditorType.CHECKBOX, Collections.emptyList());
+        return configureColumn(wrapper, EditorType.CHECKBOX,
+                Collections.emptyList());
     }
 
     /**
-     * Constructs a new column configurator with select editor preset for column creation.
+     * Configures the column to have a select editor with the given item updater
+     * and options.
      *
-     * @param <T>
-     *            the grid bean type
      * @param itemUpdater
      *            the callback function that is called when item is changed.
-     *            It receives two arguments: item and newValue.
+     *            It receives two arguments: item, newValue.
      * @param options
-     *            options provided for the select editor type
-     * @return the instance of EditColumnConfigurator
+     *            options provided for the select editor
+     * @return the configured column
      */
-    public static <T> EditColumnConfigurator<T> select(ItemUpdater<T, String> itemUpdater, List<String> options) {
+    public Column<T> select(ItemUpdater<T, String> itemUpdater,
+            List<String> options) {
         Objects.requireNonNull(options);
 
-        return new EditColumnConfigurator<>(itemUpdater, EditorType.SELECT, options);
+        return configureColumn(itemUpdater, EditorType.SELECT, options);
     }
 
     /**
-     * Constructs a new column configurator with select editor preset for column creation.
+     * Configures the column to have a select editor with the given item updater
+     * and options.
      *
-     * @param <T>
-     *            the grid bean type
      * @param itemUpdater
      *            the callback function that is called when item is changed.
-     *            It receives two arguments: item and newValue.
+     *            It receives two arguments: item, newValue.
      * @param options
-     *            options provided for the select editor type
-     * @return the instance of EditColumnConfigurator
+     *            options provided for the select editor
+     * @return the configured column
      */
-    public static <T> EditColumnConfigurator<T> select(ItemUpdater<T, String> itemUpdater, String ...options) {
+    public Column<T> select(ItemUpdater<T, String> itemUpdater,
+            String... options) {
         return select(itemUpdater, Arrays.asList(options));
     }
 
     /**
-     * Constructs a new column configurator with select editor preset for column creation based on an enum.
+     * Configures the column to have a select editor with the given item
+     * updater, enum type and string representation callback. All constants from
+     * the given enum will be used, in their natural order. To exclude some
+     * constants or use a different order, build the list of options manually
+     * and use {@link #select(ItemUpdater, String...)}.
      *
-     * @param <T>
-     *            the grid bean type
      * @param <E>
      *            the enum type
+     * @param itemUpdater
+     *            the callback function that is called when item is changed.
+     *            It receives two arguments: item and newValue.
      * @param enumType
      *            the enum class
      * @param getStringRepresentation
      *            callback used to get the string representation for each enum constant.
-     * @param itemUpdater
-     *            the callback function that is called when item is changed.
-     *            It receives two arguments: item and newValue.
-     * @return the instance of EditColumnConfigurator
+     * @return the configured column
+     *
      * @throws IllegalArgumentException
      *             if any of the enum constants have the same string representation
      */
-    public static <T, E extends Enum<E>> EditColumnConfigurator<T> select(ItemUpdater<T, E> itemUpdater, Class<E> enumType, SerializableFunction<E, String> getStringRepresentation) {
+    public <E extends Enum<E>> Column<T> select(ItemUpdater<T, E> itemUpdater,
+            Class<E> enumType,
+            SerializableFunction<E, String> getStringRepresentation) {
         Map<String, E> map = new HashMap<>();
         E[] items = enumType.getEnumConstants();
         List<String> itemsList = new ArrayList<>();
@@ -164,21 +180,23 @@ public class EditColumnConfigurator<T> implements Serializable {
     }
 
     /**
-     * Constructs a new column configurator with select editor preset for column creation based the toString() values of an enum.
+     * Configures the column to have a select editor with the given item
+     * updater, enum type using toString() as the string representation. All
+     * constants from the given enum will be used, in their natural order. To
+     * exclude some constants or use a different order, build the list of
+     * options manually and use {@link #select(ItemUpdater, String...)}.
      *
-     * @param <T>
-     *            the grid bean type
      * @param <E>
      *            the enum type
-     * @param enumType
-     *            the enum class
      * @param itemUpdater
      *            the callback function that is called when item is changed.
      *            It receives two arguments: item and newValue.
-     * @return the instance of EditColumnConfigurator
+     * @param enumType
+     *            the enum class
+     * @return the configured column
      */
-    public static <T, E extends Enum<E>> EditColumnConfigurator<T> select(ItemUpdater<T, E> itemUpdater, Class<E> enumType) {
+    public <E extends Enum<E>> Column<T> select(ItemUpdater<T, E> itemUpdater,
+            Class<E> enumType) {
         return select(itemUpdater, enumType, Object::toString);
     }
 }
-

--- a/vaadin-grid-pro-flow/src/test/java/com/vaadin/flow/component/gridpro/GridProEditColumnConfiguratorTest.java
+++ b/vaadin-grid-pro-flow/src/test/java/com/vaadin/flow/component/gridpro/GridProEditColumnConfiguratorTest.java
@@ -6,20 +6,27 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
+import com.vaadin.flow.component.gridpro.GridPro.EditColumn;
+
 import java.util.ArrayList;
 import java.util.List;
 
 public class GridProEditColumnConfiguratorTest {
 
-    EditColumnConfigurator configurator;
+    EditColumnConfigurator<Person> configurator;
     ItemUpdater testItemUpdater;
     List<String> listOptions;
+    EditColumn<Person> column;
 
     @Rule
     public ExpectedException thrown = ExpectedException.none();
 
     @Before
     public void init() {
+        GridPro<Person> grid = new GridPro<>();
+        configurator = grid.addEditColumn(value -> value);
+        column = (EditColumn<Person>) configurator.getColumn();
+
         testItemUpdater = (item, newValue) -> {};
         listOptions = new ArrayList<>();
         listOptions.add("foo");
@@ -29,15 +36,15 @@ public class GridProEditColumnConfiguratorTest {
 
     @Test
     public void shouldConfigureTextEditColumnPreset() {
-        configurator = EditColumnConfigurator.text(testItemUpdater);
+        configurator.text(testItemUpdater);
 
-        Assert.assertEquals(configurator.getType(), EditorType.TEXT);
-        Assert.assertEquals(configurator.getItemUpdater(), testItemUpdater);
+        Assert.assertEquals(column.getEditorType(), EditorType.TEXT.getTypeName());
+        Assert.assertEquals(column.getItemUpdater(), testItemUpdater);
     }
 
     @Test
     public void shouldConfigureCheckboxEditColumnPreset() {
-        Object initialItem = new Object();
+        Person initialItem = new Person(null, 0);
         String initialValue = "true";
 
         testItemUpdater = (item, newValue) -> {
@@ -45,67 +52,67 @@ public class GridProEditColumnConfiguratorTest {
             Assert.assertTrue(Boolean.parseBoolean(initialValue));
         };
 
-        configurator = EditColumnConfigurator.checkbox(testItemUpdater);
-        Assert.assertEquals(configurator.getType(), EditorType.CHECKBOX);
-        configurator.getItemUpdater().accept(initialItem, initialValue);
+        configurator.checkbox(testItemUpdater);
+        Assert.assertEquals(column.getEditorType(), EditorType.CHECKBOX.getTypeName());
+        column.getItemUpdater().accept(initialItem, initialValue);
     }
 
     @Test
     public void shouldConfigureSelectEditColumnPreset() {
-        configurator = EditColumnConfigurator.select(testItemUpdater, listOptions);
+        configurator.select(testItemUpdater, listOptions);
 
-        Assert.assertEquals(configurator.getType(), EditorType.SELECT);
-        Assert.assertEquals(configurator.getItemUpdater(), testItemUpdater);
-        Assert.assertEquals(configurator.getOptions(), listOptions);
+        Assert.assertEquals(column.getEditorType(), EditorType.SELECT.getTypeName());
+        Assert.assertEquals(column.getItemUpdater(), testItemUpdater);
+        Assert.assertEquals(column.getOptions(), listOptions);
     }
 
     @Test
     public void shouldConfigureSelectEditColumnEnumPreset() {
-        configurator = EditColumnConfigurator.select(testItemUpdater, "foo", "bar", "baz");
+        configurator.select(testItemUpdater, "foo", "bar", "baz");
 
-        Assert.assertEquals(configurator.getType(), EditorType.SELECT);
-        Assert.assertEquals(configurator.getItemUpdater(), testItemUpdater);
-        Assert.assertEquals(configurator.getOptions(), listOptions);
+        Assert.assertEquals(column.getEditorType(), EditorType.SELECT.getTypeName());
+        Assert.assertEquals(column.getItemUpdater(), testItemUpdater);
+        Assert.assertEquals(column.getOptions(), listOptions);
     }
 
     @Test
     public void shouldConfigureSelectEditColumnEnumToStringPreset() {
-        Object initialItem = new Object();
+        Person initialItem = new Person(null, 0);
         String initialValue = "bar";
 
         testItemUpdater = (item, newValue) -> {
             Assert.assertEquals(initialItem, item);
-            Assert.assertEquals(initialValue, ((testEnum) newValue).getStringRepresentation());
+            Assert.assertEquals(initialValue, ((TestEnum) newValue).getStringRepresentation());
         };
-        configurator = EditColumnConfigurator.select(testItemUpdater, testEnum.class, testEnum::getStringRepresentation);
+        configurator.select(testItemUpdater, TestEnum.class, TestEnum::getStringRepresentation);
 
-        Assert.assertEquals(configurator.getType(), EditorType.SELECT);
-        Assert.assertEquals(configurator.getOptions(), listOptions);
-        configurator.getItemUpdater().accept(initialItem, initialValue);
+        Assert.assertEquals(column.getEditorType(), EditorType.SELECT.getTypeName());
+        Assert.assertEquals(column.getOptions(), listOptions);
+        column.getItemUpdater().accept(initialItem, initialValue);
     }
 
     @Test
     public void shouldConfigureSelectEditColumnEnumDefaultPreset() {
-        Object initialItem = new Object();
+        Person initialItem = new Person(null, 0);
         String initialValue = "bar";
 
         testItemUpdater = (item, newValue) -> {
             Assert.assertEquals(initialItem, item);
-            Assert.assertEquals(initialValue, ((testEnum) newValue).getStringRepresentation());
+            Assert.assertEquals(initialValue, ((TestEnum) newValue).getStringRepresentation());
         };
-        configurator = EditColumnConfigurator.select(testItemUpdater, testEnum.class);
+        configurator.select(testItemUpdater, TestEnum.class);
 
-        Assert.assertEquals(configurator.getType(), EditorType.SELECT);
-        Assert.assertEquals(configurator.getOptions(), listOptions);
-        configurator.getItemUpdater().accept(initialItem, initialValue);
+        Assert.assertEquals(column.getEditorType(), EditorType.SELECT.getTypeName());
+        Assert.assertEquals(column.getOptions(), listOptions);
+        column.getItemUpdater().accept(initialItem, initialValue);
     }
 
-    private enum testEnum {
+    private enum TestEnum {
         FOO("foo"), BAR("bar"), BAZ("baz");
 
         private String stringRepresentation;
 
-        testEnum(String stringRepresentation) {
+        TestEnum(String stringRepresentation) {
             this.stringRepresentation = stringRepresentation;
         }
 

--- a/vaadin-grid-pro-flow/src/test/java/com/vaadin/flow/component/gridpro/GridProEditColumnTest.java
+++ b/vaadin-grid-pro-flow/src/test/java/com/vaadin/flow/component/gridpro/GridProEditColumnTest.java
@@ -1,14 +1,16 @@
 package com.vaadin.flow.component.gridpro;
 
-import com.vaadin.flow.function.SerializableBiConsumer;
+import java.util.ArrayList;
+import java.util.List;
+
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
-import java.util.ArrayList;
-import java.util.List;
+import com.vaadin.flow.component.grid.Grid;
+import com.vaadin.flow.component.gridpro.GridPro.EditColumn;
 
 public class GridProEditColumnTest {
 
@@ -30,14 +32,14 @@ public class GridProEditColumnTest {
         };
 
         grid = new GridPro<>();
-        textColumn = grid.addEditColumn(str -> str, EditColumnConfigurator.text(itemUpdater));
-        checkboxColumn = grid.addEditColumn(str -> str, EditColumnConfigurator.checkbox(itemUpdater));
+        textColumn = (EditColumn<String>) grid.addEditColumn(str -> str).text(itemUpdater);
+        checkboxColumn = (EditColumn<String>) grid.addEditColumn(str -> str).checkbox(itemUpdater);
 
         listOptions = new ArrayList<>();
         listOptions.add("foo");
         listOptions.add("bar");
         listOptions.add("baz");
-        selectColumn = grid.addEditColumn(str -> str, EditColumnConfigurator.select(itemUpdater, listOptions));
+        selectColumn = (EditColumn<String>) grid.addEditColumn(str -> str).select(itemUpdater, listOptions);
     }
 
     @Test
@@ -87,7 +89,7 @@ public class GridProEditColumnTest {
     public void addColumn_changeEditorType() {
         GridPro<Person> grid = new GridPro<>();
 
-        GridPro.EditColumn<Person> nameColumn = grid.addEditColumn(Person::getName, EditColumnConfigurator.text((item, newValue) -> {}));
+        GridPro.EditColumn<Person> nameColumn = (EditColumn<Person>) grid.addEditColumn(Person::getName).text((item, newValue) -> {});
         nameColumn.setEditorType(EditorType.CHECKBOX);
         Assert.assertEquals(nameColumn.getEditorType(), EditorType.CHECKBOX.getTypeName());
 
@@ -100,7 +102,7 @@ public class GridProEditColumnTest {
 
     @Test
     public void addEditColumn_returnsNonNullAndEditColumnType() {
-        GridPro.EditColumn column = new GridPro<Person>().addEditColumn(str -> str, EditColumnConfigurator.text((item, newValue) -> {}));
+        Grid.Column<Person> column = new GridPro<Person>().addEditColumn(str -> str).text((item, newValue) -> {});
         Assert.assertNotNull(column);
         Assert.assertEquals(GridPro.EditColumn.class, column.getClass());
     }

--- a/vaadin-grid-pro-flow/src/test/java/com/vaadin/flow/component/gridpro/GridProTest.java
+++ b/vaadin-grid-pro-flow/src/test/java/com/vaadin/flow/component/gridpro/GridProTest.java
@@ -6,10 +6,12 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
+import com.vaadin.flow.component.grid.Grid;
+
 public class GridProTest {
 
     GridPro<String> grid;
-    GridPro.EditColumn<String> textColumn;
+    Grid.Column<String> textColumn;
 
     @Rule
     public ExpectedException thrown = ExpectedException.none();
@@ -17,7 +19,7 @@ public class GridProTest {
     @Before
     public void init() {
         grid = new GridPro<>();
-        textColumn = grid.addEditColumn(str -> str, EditColumnConfigurator.text((item, newValue) -> {}));
+        textColumn = grid.addEditColumn(str -> str).text((item, newValue) -> {});
     }
 
     @Test


### PR DESCRIPTION
All addEditColumn methods are changed to return a configurer that can be
used to complete the configuration. This removes the need for calling
static factory methods for creating a configurer. The previous factory
methods are changed to instance methods that configure the column
accordingly and then return it for further chaining.