### PR TITLE
Add test for bean type grid and property name column overload

### DIFF
--- a/vaadin-grid-pro-flow-integration-tests/src/main/java/com/vaadin/flow/component/gridpro/examples/MainView.java
+++ b/vaadin-grid-pro-flow-integration-tests/src/main/java/com/vaadin/flow/component/gridpro/examples/MainView.java
@@ -18,6 +18,7 @@ public class MainView extends VerticalLayout {
 
     public MainView() {
         createEditorColumns();
+        createBeanGridWithEditColumns();
     }
 
     protected void createEditorColumns() {
@@ -55,6 +56,16 @@ public class MainView extends VerticalLayout {
         }, listOptions).setHeader("Department").setWidth("300px");
 
         add(grid, itemDisplayPanel, subPropertyDisplayPanel);
+    }
+
+    protected void createBeanGridWithEditColumns() {
+        GridPro<Person> beanGrid = new GridPro<>(Person.class);
+        beanGrid.setColumns();
+        beanGrid.setItems(createItems());
+
+        beanGrid.addEditColumn("name").text((item, newValue) -> item.setEmail(newValue));
+
+        add(beanGrid);
     }
 
     private static List<Person> createItems() {

--- a/vaadin-grid-pro-flow-integration-tests/src/main/java/com/vaadin/flow/component/gridpro/examples/MainView.java
+++ b/vaadin-grid-pro-flow-integration-tests/src/main/java/com/vaadin/flow/component/gridpro/examples/MainView.java
@@ -63,7 +63,7 @@ public class MainView extends VerticalLayout {
         beanGrid.setColumns();
         beanGrid.setItems(createItems());
 
-        beanGrid.addEditColumn("name").text((item, newValue) -> item.setEmail(newValue));
+        beanGrid.addEditColumn("name").text((item, newValue) -> item.setName(newValue));
 
         add(beanGrid);
     }

--- a/vaadin-grid-pro-flow-integration-tests/src/test/java/com/vaadin/flow/component/gridpro/test/BasicIT.java
+++ b/vaadin-grid-pro-flow-integration-tests/src/test/java/com/vaadin/flow/component/gridpro/test/BasicIT.java
@@ -12,18 +12,25 @@ import java.util.List;
 
 public class BasicIT extends AbstractParallelTest {
 
-    private GridProElement grid;
+    private GridProElement grid, beanGrid;
 
     @Before
     public void init() {
         getDriver().get(getBaseURL());
         grid = $(GridProElement.class).waitForFirst();
+        beanGrid = $(GridProElement.class).get(1);
     }
 
     @Test
     public void editColumnsAdded() {
         List<TestBenchElement> columns = grid.$("vaadin-grid-pro-edit-column").all();
         Assert.assertEquals(columns.size(), 3);
+    }
+
+    @Test
+    public void columnIsRenderedInBeanGrid() {
+        GridTHTDElement cell = beanGrid.getCell(0, 0);
+        Assert.assertEquals("Person 1", cell.getInnerHTML());
     }
 
     @Test

--- a/vaadin-grid-pro-flow-integration-tests/src/test/java/com/vaadin/flow/component/gridpro/test/BasicIT.java
+++ b/vaadin-grid-pro-flow-integration-tests/src/test/java/com/vaadin/flow/component/gridpro/test/BasicIT.java
@@ -31,6 +31,10 @@ public class BasicIT extends AbstractParallelTest {
     public void columnIsRenderedInBeanGrid() {
         GridTHTDElement cell = beanGrid.getCell(0, 0);
         Assert.assertEquals("Person 1", cell.getInnerHTML());
+        // Entering edit mode with double click
+        executeScript("var cellContent = arguments[0].firstElementChild.assignedNodes()[0];" +
+                "cellContent.dispatchEvent(new CustomEvent('dblclick', {composed: true, bubbles: true}));", cell);
+        Assert.assertTrue(cell.innerHTMLContains("vaadin-grid-pro-edit-text-field"));
     }
 
     @Test

--- a/vaadin-grid-pro-flow-integration-tests/src/test/java/com/vaadin/flow/component/gridpro/test/BasicIT.java
+++ b/vaadin-grid-pro-flow-integration-tests/src/test/java/com/vaadin/flow/component/gridpro/test/BasicIT.java
@@ -31,10 +31,7 @@ public class BasicIT extends AbstractParallelTest {
     public void columnIsRenderedInBeanGrid() {
         GridTHTDElement cell = beanGrid.getCell(0, 0);
         Assert.assertEquals("Person 1", cell.getInnerHTML());
-        // Entering edit mode with double click
-        executeScript("var cellContent = arguments[0].firstElementChild.assignedNodes()[0];" +
-                "cellContent.dispatchEvent(new CustomEvent('dblclick', {composed: true, bubbles: true}));", cell);
-        Assert.assertTrue(cell.innerHTMLContains("vaadin-grid-pro-edit-text-field"));
+        AssertCellEnterEditModeOnDoubleClick(0, 0, "vaadin-grid-pro-edit-text-field", beanGrid);
     }
 
     @Test
@@ -117,6 +114,10 @@ public class BasicIT extends AbstractParallelTest {
     }
 
     private void AssertCellEnterEditModeOnDoubleClick(Integer rowIndex, Integer colIndex, String editorTag) {
+        AssertCellEnterEditModeOnDoubleClick(rowIndex, colIndex, editorTag, grid);
+    }
+
+    private void AssertCellEnterEditModeOnDoubleClick(Integer rowIndex, Integer colIndex, String editorTag, GridProElement grid) {
         GridTHTDElement cell = grid.getCell(rowIndex, colIndex);
 
         // Not in edit mode initially


### PR DESCRIPTION
Fixes #24 
Other tests were created in https://github.com/vaadin/vaadin-grid-pro-flow/pull/32 and https://github.com/vaadin/vaadin-grid-pro-flow/pull/34

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-grid-pro-flow/35)
<!-- Reviewable:end -->
