### PR TITLE
Bump versions and fix IT jetty run

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>flow-component-base</artifactId>
-        <version>2.0.0.beta1</version>
+        <version>2.0-SNAPSHOT</version>
         <relativePath />
     </parent>
 

--- a/vaadin-grid-pro-flow-demo/pom.xml
+++ b/vaadin-grid-pro-flow-demo/pom.xml
@@ -46,17 +46,17 @@
         <dependency>
             <groupId>com.vaadin</groupId>
             <artifactId>vaadin-button-flow</artifactId>
-            <version>2.0-SNAPSHOT</version>
+            <version>2.0.0.rc1</version>
         </dependency>
         <dependency>
             <groupId>com.vaadin</groupId>
             <artifactId>vaadin-icons-flow</artifactId>
-            <version>2.0-SNAPSHOT</version>
+            <version>2.0.0.rc1</version>
         </dependency>
         <dependency>
             <groupId>com.vaadin</groupId>
             <artifactId>vaadin-form-layout-flow</artifactId>
-            <version>2.0-SNAPSHOT</version>
+            <version>2.0.0.rc1</version>
         </dependency>
     </dependencies>
 

--- a/vaadin-grid-pro-flow-integration-tests/pom.xml
+++ b/vaadin-grid-pro-flow-integration-tests/pom.xml
@@ -59,7 +59,7 @@
         <dependency>
             <groupId>com.vaadin</groupId>
             <artifactId>vaadin-text-field-flow</artifactId>
-            <version>2.0.0.rc1</version>
+            <version>2.0.0.rc2</version>
         </dependency>
 
         <!--Flow-->

--- a/vaadin-grid-pro-flow-integration-tests/pom.xml
+++ b/vaadin-grid-pro-flow-integration-tests/pom.xml
@@ -35,12 +35,12 @@
         <dependency>
             <groupId>com.vaadin</groupId>
             <artifactId>vaadin-button-flow</artifactId>
-            <version>2.0-SNAPSHOT</version>
+            <version>2.0.0.rc1</version>
         </dependency>
         <dependency>
             <groupId>com.vaadin</groupId>
             <artifactId>vaadin-ordered-layout-flow</artifactId>
-            <version>2.0-SNAPSHOT</version>
+            <version>2.0.0.rc1</version>
         </dependency>
 
         <!--System under test-->
@@ -53,13 +53,13 @@
         <dependency>
             <groupId>com.vaadin</groupId>
             <artifactId>vaadin-combo-box-flow</artifactId>
-            <version>3.0-SNAPSHOT</version>
+            <version>3.0.0.rc1</version>
         </dependency>
 
         <dependency>
             <groupId>com.vaadin</groupId>
             <artifactId>vaadin-text-field-flow</artifactId>
-            <version>2.0-SNAPSHOT</version>
+            <version>2.0.0.rc1</version>
         </dependency>
 
         <!--Flow-->
@@ -107,32 +107,21 @@
             </plugin>
 
             <plugin>
-                <groupId>org.eclipse.jetty</groupId>
-                <artifactId>jetty-maven-plugin</artifactId>
-                <configuration combine.self="override">
-                    <skip>${skipITs}</skip>
-                    <scanIntervalSeconds>2</scanIntervalSeconds>
-                    <stopKey>STOP</stopKey>
-                    <stopPort>8005</stopPort>
-                </configuration>
-            </plugin>
-
-            <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>properties-maven-plugin</artifactId>
                 <version>1.0.0</version>
                 <executions>
                     <execution>
-                        <id>read-local-properties-if-present</id>
-                        <phase>initialize</phase>
                         <goals>
-                            <goal>read-project-properties</goal>
+                            <goal>set-system-properties</goal>
                         </goals>
                         <configuration>
-                            <files>
-                                <file>../local.properties</file>
-                            </files>
-                            <quiet>true</quiet>
+                            <properties>
+                                <property>
+                                    <name>vaadin.bowerMode</name>
+                                    <value>false</value>
+                                </property>
+                            </properties>
                         </configuration>
                     </execution>
                 </executions>

--- a/vaadin-grid-pro-flow/pom.xml
+++ b/vaadin-grid-pro-flow/pom.xml
@@ -64,7 +64,7 @@
         <dependency>
             <groupId>com.vaadin</groupId>
             <artifactId>vaadin-grid-flow</artifactId>
-            <version>4.0-SNAPSHOT</version>
+            <version>4.0.0.rc1</version>
         </dependency>
         <dependency>
             <groupId>org.webjars.bowergithub.vaadin</groupId>


### PR DESCRIPTION
This will pass when we have a new version of text-field-flow, and update the commit

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-grid-pro-flow/48)
<!-- Reviewable:end -->
